### PR TITLE
#1 make fallback to an empty array when getting the current item

### DIFF
--- a/src/lib/items-storage.ts
+++ b/src/lib/items-storage.ts
@@ -18,7 +18,7 @@ class ItemsStorage {
 
   public getItems(): Item[] | null {
     try {
-      const items = this.storage.getItems();
+      const items = this.storage.getItems() ?? [];
       if (!isValidItems(items)) {
         throw new Error('Invalid items');
       }
@@ -36,7 +36,7 @@ class ItemsStorage {
         throw new Error('Invalid item fields');
       }
 
-      const currentItems = this.storage.getItems();
+      const currentItems = this.storage.getItems() ?? [];
       if (!isValidItems(currentItems)) {
         throw new Error('Invalid items');
       }


### PR DESCRIPTION
Fixing [Cannot add an item because the "Invalid items" error is thrown #1](https://github.com/yutakusuno/type-safe-local-storage/issues/1).